### PR TITLE
Update for ceci version 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "deprecated",
-    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
+    "pz-rail-base>=1.0.3",
     "jaxlib",
     "dsps",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "deprecated",
-    "ceci2 @ https://github.com/LSSTDESC/rail_base",
+    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
     "jaxlib",
     "dsps",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "deprecated",
-    "ceci2 @ git+https://github.com/LSSTDESC/rail_base",
+    "pz_rail_base @ git+https://github.com/LSSTDESC/rail_base@ceci2",
     "jaxlib",
     "dsps",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "deprecated",
-    "pz-rail-base",
+    "ceci2 @ https://github.com/LSSTDESC/rail_base",
     "jaxlib",
     "dsps",
 ]

--- a/src/rail/creation/engines/dsps_photometry_creator.py
+++ b/src/rail/creation/engines/dsps_photometry_creator.py
@@ -83,7 +83,7 @@ class DSPSPhotometryCreator(Creator):
         args:
         comm:
         """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
 
         if not os.path.isfile(self.config.ssp_templates_file):
             default_files_folder = find_rail_file(os.path.join('examples_data', 'creation_data', 'data',

--- a/src/rail/creation/engines/dsps_photometry_creator.py
+++ b/src/rail/creation/engines/dsps_photometry_creator.py
@@ -70,7 +70,7 @@ class DSPSPhotometryCreator(Creator):
     inputs = [("model", Hdf5Handle)]
     outputs = [("output", Hdf5Handle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """
         Initialize DSPSPhotometryCreator class. If the SSP templates are not provided by the user, they are automatically
         downloaded from the public NERSC directory. These default templates are created with default FSPS values,
@@ -83,7 +83,7 @@ class DSPSPhotometryCreator(Creator):
         args:
         comm:
         """
-        RailStage.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
 
         if not os.path.isfile(self.config.ssp_templates_file):
             default_files_folder = find_rail_file(os.path.join('examples_data', 'creation_data', 'data',

--- a/src/rail/creation/engines/dsps_sed_modeler.py
+++ b/src/rail/creation/engines/dsps_sed_modeler.py
@@ -90,7 +90,7 @@ class DSPSSingleSedModeler(Modeler):
         comm:
 
         """
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
 
         self.wavelength_range_mask = None
         self.restframe_wavelength_range = None
@@ -337,7 +337,7 @@ class DSPSPopulationSedModeler(Modeler):
         comm:
         """
 
-        super().__init__(self, args, **kwargs)
+        super().__init__(args, **kwargs)
 
         self.wavelength_range_mask = None
         self.restframe_wavelength_range = None

--- a/src/rail/creation/engines/dsps_sed_modeler.py
+++ b/src/rail/creation/engines/dsps_sed_modeler.py
@@ -78,7 +78,7 @@ class DSPSSingleSedModeler(Modeler):
     inputs = [("input", Hdf5Handle)]
     outputs = [("model", Hdf5Handle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         """
         Initialize SedModeler class. If the SSP templates are not provided by the user, they are automatically
         downloaded from the public NERSC directory. These default templates are created with default FSPS values,
@@ -90,7 +90,7 @@ class DSPSSingleSedModeler(Modeler):
         comm:
 
         """
-        RailStage.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
 
         self.wavelength_range_mask = None
         self.restframe_wavelength_range = None
@@ -323,7 +323,7 @@ class DSPSPopulationSedModeler(Modeler):
     inputs = [("input", Hdf5Handle)]
     outputs = [("model", Hdf5Handle)]
 
-    def __init__(self, args, comm=None):
+    def __init__(self, args, **kwargs):
         r"""
         Initialize SedModeler class. If the SSP templates are not provided by the user, they are automatically
         downloaded from the public NERSC directory. These default templates are created with default FSPS values,
@@ -337,7 +337,7 @@ class DSPSPopulationSedModeler(Modeler):
         comm:
         """
 
-        RailStage.__init__(self, args, comm=comm)
+        super().__init__(self, args, **kwargs)
 
         self.wavelength_range_mask = None
         self.restframe_wavelength_range = None


### PR DESCRIPTION
This PR updates the constructors of all stage subclasses to work with ceci version 2, in which aliases are specified in the constructor. A similar PR has been opened for each RAIL repo.

The main change is to the the constructors to accept any keywords with **kwargs and pass them to the parent class.

I have also removed any constructors which did not do anything except call the parent class constructor. Since this happens automatically if you omit the constructor, these were redundant.

Finally, in constructors I have changed I have removed hard-coded parent classes in favour of the python3 recommended super() function. If the parent class are changed in the future the constructor will still work.